### PR TITLE
Allowed for relative paths in input

### DIFF
--- a/opensauce/praat.py
+++ b/opensauce/praat.py
@@ -186,7 +186,7 @@ def praat_raw_pitch(wav_fn, praat_path, frame_shift=1, method='cc',
         raise OSError('Praat error')
 
     # Path for Praat F0 output file corresponding to wav_fn
-    f0_fn = wav_fn.split('.')[0] + ext
+    f0_fn = os.path.splitext(wav_fn)[0] + ext
     # Load data from f0 file
     if os.path.isfile(f0_fn):
         # Check if file is empty
@@ -316,7 +316,7 @@ def praat_raw_formants(wav_fn, praat_path, frame_shift=1, window_size=25, num_fo
         raise OSError('Praat error')
 
     # Path for Praat output file corresponding to wav_fn
-    fmt_fn = wav_fn.split('.')[0] + '.pfmt'
+    fmt_fn = os.path.splitext(wav_fn)[0] + '.pfmt'
     # Load results from Praat file
     if os.path.isfile(fmt_fn):
         # Praat allows half integer values for num_formants

--- a/opensauce/snack.py
+++ b/opensauce/snack.py
@@ -149,7 +149,7 @@ def snack_raw_pitch_exe(wav_fn, frame_shift, window_size, max_pitch, min_pitch):
         raise OSError('snack.exe error')
 
     # Path for f0 file corresponding to wav_fn
-    f0_fn = wav_fn.split('.')[0] + '.f0'
+    f0_fn = os.path.splitext(wav_fn)[0] + '.f0'
     # Load data from f0 file
     if os.path.isfile(f0_fn):
         F0_raw, V_raw = np.loadtxt(f0_fn, dtype=float, usecols=(0,1), unpack=True)
@@ -419,7 +419,7 @@ def snack_raw_formants_exe(wav_fn, frame_shift, window_size, pre_emphasis, lpc_o
         raise OSError('snack.exe error')
 
     # Path for frm file corresponding to wav_fn
-    frm_fn = wav_fn.split('.')[0] + '.frm'
+    frm_fn = os.path.splitext(wav_fn)[0] + '.frm'
     # Load data from frm file
     if os.path.isfile(frm_fn):
         frm_results = np.loadtxt(frm_fn, dtype=float)


### PR DESCRIPTION
Currently, relative paths that go up a directory level will not work properly, due to a couple `wav_fn.split('.')`s. I changed these in this PR to use the os.path.splitext function instead, so that `../path/to/file.wav` works properly. Before, any file with `../` would lead to a `Praat error -- unable to locate .pfmt file` error. 